### PR TITLE
[REF] project: Convert Task Force relation from Many2many to One2one

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -17,11 +17,15 @@
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['base', 'hr'],
+    'depends': ['base', 'hr', 'project'],
 
     # always loaded
     'data': [
         'views/hr_employee_view.xml',
+        'views/project_project.xml',
+        'views/task_force_views.xml',
+        'views/task_force_menu.xml',
+        'security/ir.model.access.csv',
     ],
     # only loaded in demonstration mode
     'demo': [

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,3 @@
 from . import hr_employee
+from . import task_force
+from . import project_project

--- a/models/project_project.py
+++ b/models/project_project.py
@@ -4,4 +4,8 @@ from odoo import models, fields
 class ProjectProject(models.Model):
     _inherit = "project.project"
 
-    task_force_ids = fields.Many2many('task.force', 'active_task_force', 'project_id', 'task_force_ids')
+    task_force_id = fields.Many2one('task.force', string='Task Force', readonly=False   )
+
+    _sql_constraints = [
+        ('unique_task_force', 'unique(task_force_id)', 'Each task force can be assigned to only one project.')
+    ]

--- a/models/project_project.py
+++ b/models/project_project.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    task_force_ids = fields.Many2many('task.force', 'active_task_force', 'project_id', 'task_force_ids')

--- a/models/task_force.py
+++ b/models/task_force.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+class TaskForce(models.Model):
+    _name = "task.force"
+    _description = "Task Force for projects"
+
+    name = fields.Char(string='Name', help='Task Force Name')
+    manager_id = fields.Many2one('hr.employee', 'Manager')
+    members_ids = fields.Many2many('hr.employee', 'task_force_member', 'task_force_id', 'emp_id', string='Members')

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+sti_odoo_teams.access_task_force,access_task.force,sti_odoo_teams.model_task_force,base.group_user,1,1,1,1

--- a/views/project_project.xml
+++ b/views/project_project.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_project_view_form_involved_task_force" model="ir.ui.view">
+        <field name="name">project.project.view.form.involved.task.force</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="priority">24</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="task_force_ids" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/views/project_project.xml
+++ b/views/project_project.xml
@@ -7,7 +7,7 @@
         <field name="priority">24</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="after">
-                <field name="task_force_ids" widget="many2many_tags"/>
+                <field name="task_force_id"/>
             </xpath>
         </field>
     </record>

--- a/views/task_force_menu.xml
+++ b/views/task_force_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <menuitem
+                id="menu_task_force_tree"
+                action="task_force_tree_action"
+                parent="hr.menu_config_employee"
+                sequence="5"
+                groups="hr.group_hr_user"/>
+    </data>
+</odoo>

--- a/views/task_force_views.xml
+++ b/views/task_force_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_task_force_form" model="ir.ui.view">
+            <field name="name">task.force.form</field>
+            <field name="model">task.force</field>
+            <field name="arch" type="xml">
+                <form string="Task Force">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name"/>
+                                <field name="members_ids" widget="many2many_tags"/>
+                                <field name="manager_id"/>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_task_force_tree" model="ir.ui.view">
+            <field name="name">task.force.tree</field>
+            <field name="model">task.force</field>
+            <field name="arch" type="xml">
+                <tree string="Companies" sample="1" editable="bottom">
+                    <field name="name"/>
+                    <field name="manager_id"/>
+                    <field name="members_ids" widget="many2many_tags"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_task_force_filter" model="ir.ui.view">
+            <field name="name">task.force.search</field>
+            <field name="model">task.force</field>
+            <field name="arch" type="xml">
+                <search string="Task Force Name">
+                    <field name="name" string="Task Force Name"/>
+                </search>
+            </field>
+        </record>
+        <record id="task_force_tree_action" model="ir.actions.act_window">
+            <field name="name">Task Force</field>
+            <field name="res_model">task.force</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        <!-- TODO:
+                * Add Kanban view with color field to recognize the team from the color
+                * Add Hierarchy view-->
+    </data>
+</odoo>


### PR DESCRIPTION
### Summary

This PR refactors the `task_force_ids` field on the `project.project` model from a `Many2many` to a `Many2one` field, effectively turning the relationship into a `One2one` mapping between a project and a task force.

---

### Why

- The original `Many2many` relationship allowed assigning multiple task forces to a single project, which does not reflect the intended business logic.
- Based on feedback from the project lead, each project should be associated with **exactly one** task force, and each task force should be used for **only one** project.
- A `One2one` relationship better represents this constraint and simplifies the UI and data logic.

---

### What Changed

- Replaced `task_force_ids` (`Many2many`) with `task_force_id` (Many2one) in the `project.project` model.
- Added an SQL constraint to enforce that each `task_force_id` is unique (ensuring `One2one` behavior).
- Updated the project form view to use the new field.